### PR TITLE
fix: use dynamic protocol from OVPN config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ sed -E 's/auth-user-pass|auth-federate|auth-retry interact|remote-random-hostnam
 
 VPN_HOST=$(cat "$OVPN_CONF" | grep 'remote ' | awk '{ print $2}')
 PORT=$(cat "$OVPN_CONF" | grep 'remote ' | awk '{ print $3}')
+PROTO=$(cat "$OVPN_CONF" | grep '^proto ' | awk '{ print $2}')
 
 RAND=$(openssl rand -hex 12)
 SRV=$(dig a +short "${RAND}.${VPN_HOST}" | head -n1)
@@ -13,7 +14,7 @@ sed -i -E 's/remote .*//g' "$OVPN_CONF"
 
 echo "Getting SAML redirect URL from the AUTH_FAILED response (host: ${SRV}:${PORT})"
 OVPN_OUT=$(./openvpn-bin --config "$OVPN_CONF" --verb 3 \
-     --proto udp --remote "$SRV" "$PORT" \
+     --proto "${PROTO:-tcp}" --remote "$SRV" "$PORT" \
      --auth-user-pass <( printf "%s\n%s\n" "N/A" "ACS::35001" ) | grep AUTH_FAILED,CRV1)
 
 URL=$(echo "$OVPN_OUT" | grep -Eo 'https://.+')
@@ -35,7 +36,7 @@ VPN_SID=$(echo "$OVPN_OUT" | awk -F : '{print $7}')
 # Delete saml-response.txt after connect
 ./openvpn-bin --config "$OVPN_CONF" \
     --verb 3 --auth-nocache --inactive 3600 \
-    --proto udp --remote "$SRV" "$PORT" \
+    --proto "${PROTO:-tcp}" --remote "$SRV" "$PORT" \
     --script-security 2 \
     --route-up '/usr/bin/env rm /tmp/saml-response.txt' \
     --auth-user-pass <( printf "%s\n%s\n" "N/A" "CRV1::$VPN_SID::$(cat /tmp/saml-response.txt)" )


### PR DESCRIPTION
This resolves #2 for me.

It seemed that the process hanged because the original implementation used a static `--proto udp` flag.
This PR extract the `proto` value dynamically from the OVPN configuration file and pass it to both `openvpn-bin` calls